### PR TITLE
Avoid waking NVIDIA GPUs by checking runtime power status in sysfs

### DIFF
--- a/src/amd.rs
+++ b/src/amd.rs
@@ -32,6 +32,7 @@ impl GpuStatus for AmdGpuStatus {
             .current;
 
         Ok(GpuStatusData {
+            powered_on: true,
             gpu_util: gpu_handle.get_busy_percent().ok(),
             mem_used: gpu_handle
                 .get_used_vram()

--- a/src/nvidia.rs
+++ b/src/nvidia.rs
@@ -14,7 +14,9 @@ impl NvidiaGpuStatus<'_> {
         let device = instance.device_by_index(0)?;
 
         // Query PCI info just once
-        let bus_id = device.pci_info()?.bus_id; 
+        // NVML returns a PCI domain up to 0xffffffff; need to truncate
+        // to match sysfs
+        let bus_id = device.pci_info()?.bus_id.chars().skip(4).collect();
 
         Ok(Self { device, bus_id })
     }

--- a/src/nvidia.rs
+++ b/src/nvidia.rs
@@ -2,57 +2,80 @@ use crate::gpu_status::{GpuStatus, GpuStatusData, PState};
 use color_eyre::eyre::Result;
 use nvml_wrapper::enum_wrappers::device::{PcieUtilCounter, PerformanceState, TemperatureSensor};
 use nvml_wrapper::{Device, Nvml};
+use std::fs;
 
 pub struct NvidiaGpuStatus<'a> {
     device: Device<'a>,
+    bus_id: String
 }
 
 impl NvidiaGpuStatus<'_> {
     pub fn new(instance: &'static Nvml) -> Result<Self> {
         let device = instance.device_by_index(0)?;
 
-        Ok(Self { device })
+        // Query PCI info just once
+        let bus_id = device.pci_info()?.bus_id; 
+
+        Ok(Self { device, bus_id })
     }
+}
+
+fn is_powered_on(bus_id: &str) -> Result<bool, std::io::Error> {
+    let path = format!("/sys/bus/pci/devices/{}/power/runtime_status", bus_id);
+    let status = fs::read_to_string(path)?.trim().to_string();
+    let powered_on = status == "active";
+    Ok(powered_on)
 }
 
 impl GpuStatus for NvidiaGpuStatus<'_> {
     fn compute(&self) -> Result<GpuStatusData> {
-        let device = &self.device;
+        // NVML queries inadvertently wake the NVIDIA card
+        // Use sysfs to check power status first
+        let powered_on = is_powered_on(&self.bus_id)?;
+        let gpu_status = if !powered_on {
+            GpuStatusData {
+              powered_on: false,
+              ..Default::default()
+            }
+        } else {
+          let device = &self.device;
 
-        let utilization_rates = device.utilization_rates().ok();
-        let memory_info_in_bytes = device.memory_info().ok();
+          let utilization_rates = device.utilization_rates().ok();
+          let memory_info_in_bytes = device.memory_info().ok();
 
-        let gpu_status = GpuStatusData {
-            gpu_util: utilization_rates.clone().map(|u| u.gpu as u8),
-            mem_used: memory_info_in_bytes
-                .clone()
-                .map(|m| m.used as f64 / 1024f64 / 1024f64), // convert to MiB from B
-            mem_total: memory_info_in_bytes.map(|m| m.total as f64 / 1024f64 / 1024f64),
-            mem_util: utilization_rates.map(|u| u.memory as u8),
-            dec_util: device
-                .decoder_utilization()
-                .ok()
-                .map(|u| u.utilization as u8),
-            enc_util: device
-                .encoder_utilization()
-                .ok()
-                .map(|u| u.utilization as u8),
-            temp: device
-                .temperature(TemperatureSensor::Gpu)
-                .ok()
-                .map(|t| t as u8),
-            power: device.power_usage().ok().map(|p| p as f64 / 1000f64), // convert to W from mW
-            p_state: device.performance_state().ok().map(|p| p.into()),
-            fan_speed: device.fan_speed(0u32).ok().map(|f| f as u8),
-            tx: device
-                .pcie_throughput(PcieUtilCounter::Send)
-                .ok()
-                .map(|t| t as f64 / 1000f64), // convert to MiB/s from KiB/s
-            rx: device
-                .pcie_throughput(PcieUtilCounter::Receive)
-                .ok()
-                .map(|t| t as f64 / 1000f64),
-            ..Default::default()
+          GpuStatusData {
+              powered_on: true,
+              gpu_util: utilization_rates.clone().map(|u| u.gpu as u8),
+              mem_used: memory_info_in_bytes
+                  .clone()
+                  .map(|m| m.used as f64 / 1024f64 / 1024f64), // convert to MiB from B
+              mem_total: memory_info_in_bytes.map(|m| m.total as f64 / 1024f64 / 1024f64),
+              mem_util: utilization_rates.map(|u| u.memory as u8),
+              dec_util: device
+                  .decoder_utilization()
+                  .ok()
+                  .map(|u| u.utilization as u8),
+              enc_util: device
+                  .encoder_utilization()
+                  .ok()
+                  .map(|u| u.utilization as u8),
+              temp: device
+                  .temperature(TemperatureSensor::Gpu)
+                  .ok()
+                  .map(|t| t as u8),
+              power: device.power_usage().ok().map(|p| p as f64 / 1000f64), // convert to W from mW
+              p_state: device.performance_state().ok().map(|p| p.into()),
+              fan_speed: device.fan_speed(0u32).ok().map(|f| f as u8),
+              tx: device
+                  .pcie_throughput(PcieUtilCounter::Send)
+                  .ok()
+                  .map(|t| t as f64 / 1000f64), // convert to MiB/s from KiB/s
+              rx: device
+                  .pcie_throughput(PcieUtilCounter::Receive)
+                  .ok()
+                  .map(|t| t as f64 / 1000f64),
+              ..Default::default()
+          }
         };
 
         Ok(gpu_status)


### PR DESCRIPTION
Using NVML to query the status of an NVIDIA GPU wakes it up. So, this waybar module currently prevents NVIDIA GPUs from entering their lowest-power states. For  laptop users, this may defeat the whole purpose of usage monitoring. See similar discussion here: https://github.com/prasanthrangan/hyprdots/issues/685
 
The solution is to first check the `runtime_status` of the device using sysfs. If it’s inactive, then we don’t bother with the NVML queries. 

Aside from waking a sleeping device, there's (of course) the possibility of preventing an active device from sleeping. Whether this can occur depends on how big the polling interval is relative to the NVIDIA driver's internal interval. I couldn't find information on the latter, but I added an `interval` argument to this script which, if set large enough, should avoid this problem as well. 