### PR TITLE
Update #usage: add instructions for nightly users

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Add the custom module to the config
 
 ```json
 "custom/gpu-usage": {
-  "format": "{} {icon}",
+  "format": "{} {icon}", /* "{text} {icon}" for nightly users */
   "exec": "gpu-usage-waybar",
   "return-type": "json",
   "format-icons": "󰾲",


### PR DESCRIPTION
Waybar nightly does not allow mixing manual and automatic argument placeholders
```
[2025-12-26 17:02:30.392] [error] custom/gpu: mixing manual and automatic
argument indexing is no longer supported; try replacing "{}" with "{text}"
in your format specifier
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated example JSON format documentation with clarification on an alternative formatting option.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->