### PR TITLE
Eliminate internal string buffering and write directly to stdout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,19 +18,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
-name = "ahash"
-version = "0.8.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
-dependencies = [
- "cfg-if",
- "getrandom",
- "once_cell",
- "version_check",
- "zerocopy",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -139,12 +126,6 @@ name = "bumpalo"
 version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
-
-[[package]]
-name = "bytes"
-version = "1.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
 
 [[package]]
 name = "cc"
@@ -345,18 +326,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "faststr"
-version = "0.2.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baec6a0289d7f1fe5665586ef7340af82e3037207bef60f5785e57569776f0c8"
-dependencies = [
- "bytes",
- "rkyv",
- "serde",
- "simdutf8",
-]
-
-[[package]]
 name = "find-msvc-tools"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -379,18 +348,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
-name = "getrandom"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
-dependencies = [
- "cfg-if",
- "libc",
- "r-efi",
- "wasip2",
-]
-
-[[package]]
 name = "gimli"
 version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -409,7 +366,6 @@ dependencies = [
  "regex",
  "serde",
  "smart-default",
- "sonic-rs",
  "strum",
  "toml",
  "uom",
@@ -486,12 +442,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
-name = "itoa"
-version = "1.0.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
-
-[[package]]
 name = "js-sys"
 version = "0.3.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -552,26 +502,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "munge"
-version = "0.4.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e17401f259eba956ca16491461b6e8f72913a0a114e39736ce404410f915a0c"
-dependencies = [
- "munge_macro",
-]
-
-[[package]]
-name = "munge_macro"
-version = "0.4.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4568f25ccbd45ab5d5603dc34318c1ec56b117531781260002151b8530a9f931"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -590,7 +520,7 @@ dependencies = [
  "libloading",
  "nvml-wrapper-sys",
  "static_assertions",
- "thiserror 1.0.69",
+ "thiserror",
  "wrapcenum-derive",
 ]
 
@@ -670,67 +600,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "ptr_meta"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b9a0cf95a1196af61d4f1cbdab967179516d9a4a4312af1f31948f8f6224a79"
-dependencies = [
- "ptr_meta_derive",
-]
-
-[[package]]
-name = "ptr_meta_derive"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7347867d0a7e1208d93b46767be83e2b8f978c3dad35f775ac8d8847551d6fe1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
-]
-
-[[package]]
-name = "r-efi"
-version = "5.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
-
-[[package]]
-name = "rancor"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a063ea72381527c2a0561da9c80000ef822bdd7c3241b1cc1b12100e3df081ee"
-dependencies = [
- "ptr_meta",
-]
-
-[[package]]
-name = "ref-cast"
-version = "1.0.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
-dependencies = [
- "ref-cast-impl",
-]
-
-[[package]]
-name = "ref-cast-impl"
-version = "1.0.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -761,41 +636,6 @@ name = "regex-syntax"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
-
-[[package]]
-name = "rend"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cadadef317c2f20755a64d7fdc48f9e7178ee6b0e1f7fce33fa60f1d68a276e6"
-
-[[package]]
-name = "rkyv"
-version = "0.8.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "360b333c61ae24e5af3ae7c8660bd6b21ccd8200dbbc5d33c2454421e85b9c69"
-dependencies = [
- "bytes",
- "hashbrown",
- "indexmap",
- "munge",
- "ptr_meta",
- "rancor",
- "rend",
- "rkyv_derive",
- "tinyvec",
- "uuid",
-]
-
-[[package]]
-name = "rkyv_derive"
-version = "0.8.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c02f8cdd12b307ab69fe0acf4cd2249c7460eb89dce64a0febadf934ebb6a9e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "rustc-demangle"
@@ -883,12 +723,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
 
 [[package]]
-name = "simdutf8"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
-
-[[package]]
 name = "smart-default"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -897,45 +731,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "sonic-number"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8a74044c092f4f43ca7a6cfd62854cf9fb5ac8502b131347c990bf22bef1dfe"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
-name = "sonic-rs"
-version = "0.5.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d971cc77a245ccf1756dbd1a87c3e7f709c0191464096510d43eec056d0f2c4f"
-dependencies = [
- "ahash",
- "bumpalo",
- "bytes",
- "cfg-if",
- "faststr",
- "itoa",
- "ref-cast",
- "serde",
- "simdutf8",
- "sonic-number",
- "sonic-simd",
- "thiserror 2.0.18",
- "zmij",
-]
-
-[[package]]
-name = "sonic-simd"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5707edbfb34a40c9f2a55fa09a49101d9fec4e0cc171ce386086bd9616f34257"
-dependencies = [
- "cfg-if",
 ]
 
 [[package]]
@@ -988,16 +783,7 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl 1.0.69",
-]
-
-[[package]]
-name = "thiserror"
-version = "2.0.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
-dependencies = [
- "thiserror-impl 2.0.18",
+ "thiserror-impl",
 ]
 
 [[package]]
@@ -1012,17 +798,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "thiserror-impl"
-version = "2.0.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "thread_local"
 version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1030,21 +805,6 @@ checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
 ]
-
-[[package]]
-name = "tinyvec"
-version = "1.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
-dependencies = [
- "tinyvec_macros",
-]
-
-[[package]]
-name = "tinyvec_macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "toml"
@@ -1155,35 +915,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
-name = "uuid"
-version = "1.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2e054861b4bd027cd373e18e8d8d8e6548085000e41290d95ce0c373a654b4a"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
-
-[[package]]
-name = "version_check"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
-
-[[package]]
-name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
-dependencies = [
- "wit-bindgen",
-]
 
 [[package]]
 name = "wasm-bindgen"
@@ -1305,12 +1040,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
 
 [[package]]
-name = "wit-bindgen"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-
-[[package]]
 name = "wrapcenum-derive"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1321,29 +1050,3 @@ dependencies = [
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "zerocopy"
-version = "0.8.33"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "668f5168d10b9ee831de31933dc111a459c97ec93225beb307aed970d1372dfd"
-dependencies = [
- "zerocopy-derive",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.8.33"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c7962b26b0a8685668b671ee4b54d007a67d4eaf05fda79ac0ecf41e32270f1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "zmij"
-version = "1.0.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -361,6 +361,7 @@ dependencies = [
  "clap",
  "color-eyre",
  "etcetera",
+ "json-escape-simd",
  "nvml-wrapper",
  "procfs",
  "regex",
@@ -450,6 +451,12 @@ dependencies = [
  "once_cell",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "json-escape-simd"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3c2a6c0b4b5637c41719973ef40c6a1cf564f9db6958350de6193fbee9c23f5"
 
 [[package]]
 name = "lazy_static"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "getrandom",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -126,6 +139,12 @@ name = "bumpalo"
 version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
+
+[[package]]
+name = "bytes"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cc"
@@ -326,6 +345,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "faststr"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ca7d44d22004409a61c393afb3369c8f7bb74abcae49fe249ee01dcc3002113"
+dependencies = [
+ "bytes",
+ "rkyv",
+ "serde",
+ "simdutf8",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -348,6 +379,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+]
+
+[[package]]
 name = "gimli"
 version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -367,6 +410,7 @@ dependencies = [
  "regex",
  "serde",
  "smart-default",
+ "sonic-rs",
  "strum",
  "toml",
  "uom",
@@ -443,6 +487,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
 name = "js-sys"
 version = "0.3.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -509,6 +559,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "munge"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e17401f259eba956ca16491461b6e8f72913a0a114e39736ce404410f915a0c"
+dependencies = [
+ "munge_macro",
+]
+
+[[package]]
+name = "munge_macro"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4568f25ccbd45ab5d5603dc34318c1ec56b117531781260002151b8530a9f931"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -527,7 +597,7 @@ dependencies = [
  "libloading",
  "nvml-wrapper-sys",
  "static_assertions",
- "thiserror",
+ "thiserror 1.0.69",
  "wrapcenum-derive",
 ]
 
@@ -607,12 +677,67 @@ dependencies = [
 ]
 
 [[package]]
+name = "ptr_meta"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b9a0cf95a1196af61d4f1cbdab967179516d9a4a4312af1f31948f8f6224a79"
+dependencies = [
+ "ptr_meta_derive",
+]
+
+[[package]]
+name = "ptr_meta_derive"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7347867d0a7e1208d93b46767be83e2b8f978c3dad35f775ac8d8847551d6fe1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "rancor"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a063ea72381527c2a0561da9c80000ef822bdd7c3241b1cc1b12100e3df081ee"
+dependencies = [
+ "ptr_meta",
+]
+
+[[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -643,6 +768,41 @@ name = "regex-syntax"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
+
+[[package]]
+name = "rend"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cadadef317c2f20755a64d7fdc48f9e7178ee6b0e1f7fce33fa60f1d68a276e6"
+
+[[package]]
+name = "rkyv"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a30e631b7f4a03dee9056b8ef6982e8ba371dd5bedb74d3ec86df4499132c70"
+dependencies = [
+ "bytes",
+ "hashbrown",
+ "indexmap",
+ "munge",
+ "ptr_meta",
+ "rancor",
+ "rend",
+ "rkyv_derive",
+ "tinyvec",
+ "uuid",
+]
+
+[[package]]
+name = "rkyv_derive"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8100bb34c0a1d0f907143db3149e6b4eea3c33b9ee8b189720168e818303986f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "rustc-demangle"
@@ -730,6 +890,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
 
 [[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
 name = "smart-default"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -738,6 +904,45 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "sonic-number"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3775c3390edf958191f1ab1e8c5c188907feebd0f3ce1604cb621f72961dbf32"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "sonic-rs"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d971cc77a245ccf1756dbd1a87c3e7f709c0191464096510d43eec056d0f2c4f"
+dependencies = [
+ "ahash",
+ "bumpalo",
+ "bytes",
+ "cfg-if",
+ "faststr",
+ "itoa",
+ "ref-cast",
+ "serde",
+ "simdutf8",
+ "sonic-number",
+ "sonic-simd",
+ "thiserror 2.0.18",
+ "zmij",
+]
+
+[[package]]
+name = "sonic-simd"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f99e664ecd2d85a68c87e3c7a3cfe691f647ea9e835de984aba4d54a41f817d4"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -790,7 +995,16 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -805,6 +1019,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "thread_local"
 version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -812,6 +1037,21 @@ checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "toml"
@@ -922,10 +1162,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "uuid"
+version = "1.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wasip2"
+version = "1.0.2+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+dependencies = [
+ "wit-bindgen",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -1047,6 +1312,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
 
 [[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+
+[[package]]
 name = "wrapcenum-derive"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1057,3 +1328,29 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ etcetera = "0.11"
 nvml-wrapper = "0.12"
 regex = "1.12"
 serde = { version = "1.0", features = ["derive"] }
-sonic-rs = "0.5"
 smart-default = "0.7.1"
 strum = { version = "0.28", features = ["derive"] }
 toml = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,13 +17,13 @@ etcetera = "0.11"
 nvml-wrapper = "0.12"
 regex = "1.12"
 serde = { version = "1.0", features = ["derive"] }
+sonic-rs = "0.5"
 smart-default = "0.7.1"
 strum = { version = "0.28", features = ["derive"] }
 toml = "1.0"
 procfs = "0.18.0"
 uom = "0.38.0"
 json-escape-simd = "3.0.1"
-sonic-rs = "0.5.8"
 
 [profile.dev.package.backtrace]
 opt-level = 3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ strum = { version = "0.28", features = ["derive"] }
 toml = "1.0"
 procfs = "0.18.0"
 uom = "0.38.0"
+json-escape-simd = "3.0.1"
 
 [profile.dev.package.backtrace]
 opt-level = 3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ toml = "1.0"
 procfs = "0.18.0"
 uom = "0.38.0"
 json-escape-simd = "3.0.1"
+sonic-rs = "0.5.8"
 
 [profile.dev.package.backtrace]
 opt-level = 3

--- a/src/formatter/mod.rs
+++ b/src/formatter/mod.rs
@@ -48,13 +48,9 @@ impl State {
 }
 
 impl State {
-    pub fn try_from_format(format: &str) -> Result<State, UnitParseError> {
-        // Make line breaks literal (\n -> \\n),
-        // because we don't want to flush stdout
-        let format = format.replace('\n', "\\n");
-
+    pub fn try_from_format(format: impl AsRef<str>) -> Result<State, UnitParseError> {
         Ok(Self {
-            chunks: parse(&format)?,
+            chunks: parse(format.as_ref())?,
         })
     }
 }

--- a/src/formatter/mod.rs
+++ b/src/formatter/mod.rs
@@ -2,7 +2,10 @@ pub mod fields;
 pub mod units;
 
 use regex::Regex;
-use std::fmt::Debug;
+use std::{
+    fmt::Debug,
+    io::{self, Write},
+};
 
 use crate::{
     formatter::fields::*,
@@ -17,39 +20,41 @@ pub enum Chunk {
 
 pub struct State {
     pub chunks: Vec<Chunk>,
-    pub buffer: String,
 }
 
 impl State {
-    /// Assembles `self.chunks` into `self.buffer` using the provided `data`.
+    /// Writes `self.chunks` into `buffer` using the provided `data`.
     ///
     /// Writes `"N/A"` if a variable segment in `chunks` is [`Field::Unknown`],
     /// or if the corresponding field in `data` is `None`.
-    pub fn assemble(&mut self, data: &GpuStatusData) {
-        self.buffer.clear();
-
+    pub fn write(&self, buffer: &mut impl Write, data: &GpuStatusData) -> io::Result<()> {
         for chunk in &self.chunks {
             match chunk {
-                Chunk::Static(s) => self.buffer.push_str(s),
+                Chunk::Static(s) => write!(buffer, "{s}")?,
                 Chunk::Variable(field) => {
                     if matches!(
                         // write_field() writes "N/A" if field is Field::Unknown.
-                        data.write_field(*field, &mut self.buffer),
+                        data.write_field(*field, buffer),
                         Err(WriteFieldError::FieldIsNone)
                     ) {
-                        self.buffer.push_str("N/A");
+                        write!(buffer, "N/A")?;
                     }
                 }
             }
         }
+
+        Ok(())
     }
 }
 
 impl State {
     pub fn try_from_format(format: &str) -> Result<State, UnitParseError> {
+        // Make line breaks literal (\n -> \\n),
+        // because we don't want to flush stdout
+        let format = format.replace('\n', "\\n");
+
         Ok(Self {
-            chunks: parse(format)?,
-            buffer: String::new(),
+            chunks: parse(&format)?,
         })
     }
 }
@@ -76,29 +81,12 @@ pub fn get_regex() -> Regex {
     Regex::new(r"\{(\w+)(?::(\w+)(?:\.(\d+))?)?\}").unwrap()
 }
 
-pub fn trim_trailing_zeros(buf: &mut String, scan_end_index: usize) {
-    let Some(last_dot_pos) = buf.rfind('.') else {
-        return;
-    };
-
-    // do not trim zeros if the last dot pos is before scan_end_index
-    if last_dot_pos <= scan_end_index {
-        return;
-    }
-
-    let mut end = buf.len();
-
-    while end > last_dot_pos + 1 && buf.as_bytes()[end - 1] == b'0' {
-        end -= 1;
-    }
-
-    // If only '.' left
-    if end == last_dot_pos + 1 {
-        end -= 1;
-    }
-
-    buf.truncate(end);
+pub fn write_with_precision(buf: &mut impl Write, precision: usize, v: f32) -> io::Result<()> {
+    let m = 10f32.powi(precision as i32);
+    let v = (v * m).round() / m;
+    write!(buf, "{v}")
 }
+
 fn parse(format: &str) -> Result<Vec<Chunk>, UnitParseError> {
     let re = get_regex();
     let mut chunks = Vec::new();
@@ -199,37 +187,24 @@ RX: {rx:MiB.2} MiB/s";
     }
 
     #[test]
-    fn test_trim_trailing_zeros() {
-        let mut buf = "1.50000".to_string();
-        trim_trailing_zeros(&mut buf, 0);
-        assert_eq!(buf, "1.5");
-    }
+    fn write_with_precision_zeros() {
+        let mut buf = Vec::new();
+        let precision = 5;
+        write_with_precision(&mut buf, precision, 12.34).unwrap();
 
-    #[test]
-    fn test_trim_trailing_zeros_and_dot() {
-        let mut buf = "1.00000".to_string();
-        trim_trailing_zeros(&mut buf, 0);
-        assert_eq!(buf, "1");
-    }
+        // we don't want trailing zeros
+        assert_eq!(String::from_utf8(buf).unwrap(), "12.34");
 
-    #[test]
-    fn test_trim_trailing_zeros_without_decimal() {
-        let mut buf = "10000".to_string();
-        trim_trailing_zeros(&mut buf, 0);
-        assert_eq!(buf, "10000");
-    }
+        let mut buf = Vec::new();
+        write_with_precision(&mut buf, precision, 12.01234).unwrap();
 
-    #[test]
-    fn test_trim_trailing_zeros_with_previous_decimals() {
-        let mut buf = "100.00 120".to_string();
-        trim_trailing_zeros(&mut buf, 7);
-        assert_eq!(buf, "100.00 120");
-    }
+        // full digits
+        assert_eq!(String::from_utf8(buf).unwrap(), "12.01234");
 
-    #[test]
-    fn test_trim_trailing_zeros_with_mutiple_dots() {
-        let mut buf = "100.00 120.0 500.000".to_string();
-        trim_trailing_zeros(&mut buf, 13);
-        assert_eq!(buf, "100.00 120.0 500");
+        let mut buf = Vec::new();
+        write_with_precision(&mut buf, precision, 12.012343).unwrap();
+
+        // only 5 digits
+        assert_eq!(String::from_utf8(buf).unwrap(), "12.01234");
     }
 }

--- a/src/formatter/mod.rs
+++ b/src/formatter/mod.rs
@@ -81,6 +81,13 @@ pub fn get_regex() -> Regex {
     Regex::new(r"\{(\w+)(?::(\w+)(?:\.(\d+))?)?\}").unwrap()
 }
 
+/// Writes `v` to `buf` with `precision` decimal digits.
+///
+/// # Note
+///
+/// Avoid using large values for `precision` or `v` to prevent overflow.
+/// This function uses [std::f32]'s [std::fmt::Display] implementation.
+/// The value `v` will be multiplied by 10^`precision`.
 pub fn write_with_precision(buf: &mut impl Write, precision: usize, v: f32) -> io::Result<()> {
     let m = 10f32.powi(precision as i32);
     let v = (v * m).round() / m;

--- a/src/gpu_status.rs
+++ b/src/gpu_status.rs
@@ -1,10 +1,13 @@
 use amdgpu_sysfs::gpu_handle::PerformanceLevel;
 use color_eyre::eyre::Result;
-use std::fmt::{Display, Write};
+use std::{
+    fmt::Display,
+    io::{self, Write},
+};
 use strum::Display;
 use uom::si::{f32::Information, f32::Power};
 
-use crate::formatter::{self, fields::*, units::*, *};
+use crate::formatter::{fields::*, units::*, *};
 
 pub type Temperature = uom::si::f32::ThermodynamicTemperature;
 
@@ -52,46 +55,46 @@ impl GpuStatusData {
         }
     }
 
-    pub fn get_text<'a>(&self, state: &'a mut State) -> &'a str {
+    pub fn write_text(&self, state: &State, buffer: &mut impl Write) -> io::Result<()> {
         if !self.powered_on {
-            return "Off";
+            return write!(buffer, "Off");
         }
 
         if !self.has_running_processes {
-            return "Idle";
+            return write!(buffer, "Idle");
         }
 
-        state.assemble(self);
-        &state.buffer
+        state.write(buffer, self)
     }
 
-    pub fn get_tooltip<'a>(&self, state: &'a mut State) -> &'a str {
+    pub fn write_tooltip(&self, state: &State, buffer: &mut impl Write) -> io::Result<()> {
         if !self.powered_on {
-            return "GPU powered off";
+            return write!(buffer, "GPU powered off");
         }
 
         if !self.has_running_processes {
-            return "GPU idle";
+            return write!(buffer, "GPU idle");
         }
 
-        state.assemble(self);
-        &state.buffer
+        state.write(buffer, self)
     }
 
     /// Write `field` value to `buffer`.
     ///
     /// - Writes "N/A" if `field` is [Field::Unknown].
     /// - Returns [WriteFieldError::FieldIsNone] if `field` is `None`.
-    pub fn write_field(&self, field: Field, buffer: &mut String) -> Result<(), WriteFieldError> {
-        let scan_end_index = buffer.len();
-
+    pub fn write_field(
+        &self,
+        field: Field,
+        buffer: &mut impl Write,
+    ) -> Result<(), WriteFieldError> {
         macro_rules! u {
             ($val:expr, $unit:expr, $precision:expr) => {{
                 let v = $val.ok_or(WriteFieldError::FieldIsNone)?;
                 let v = $unit.compute(v);
 
                 match $precision {
-                    Some(precision) => write!(buffer, "{:.*}", precision, v).unwrap(),
+                    Some(precision) => write_with_precision(buffer, precision, v).unwrap(),
                     None => write!(buffer, "{v}").unwrap(),
                 }
             }};
@@ -106,10 +109,8 @@ impl GpuStatusData {
             } => u!(self.get_mem_field(field), unit, precision),
             Field::Temperature { unit, precision } => u!(self.temperature, unit, precision),
             Field::Power { unit, precision } => u!(self.power, unit, precision),
-            Field::Unknown => buffer.push_str("N/A"),
+            Field::Unknown => write!(buffer, "N/A").unwrap(),
         };
-
-        formatter::trim_trailing_zeros(buffer, scan_end_index);
 
         Ok(())
     }
@@ -157,7 +158,7 @@ impl GpuStatusData {
     fn write_simple_field(
         &self,
         field: SimpleField,
-        buffer: &mut String,
+        buffer: &mut impl Write,
     ) -> Result<(), WriteFieldError> {
         if let Some(field_display) = self.get_simple_field_display(field) {
             write!(buffer, "{field_display}").unwrap();
@@ -242,7 +243,7 @@ mod tests {
             temperature: Some(Temperature::new::<degree_celsius>(35.12345)),
             ..Default::default()
         };
-        let mut buf = String::new();
+        let mut buf = Vec::new();
 
         data.write_field(
             Field::Temperature {
@@ -253,7 +254,7 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(buf, "35.12");
+        assert_eq!(String::from_utf8(buf).unwrap(), "35.12");
     }
 
     #[test]
@@ -262,7 +263,7 @@ mod tests {
             temperature: Some(Temperature::new::<degree_celsius>(35.12345)),
             ..Default::default()
         };
-        let mut buf = String::new();
+        let mut buf = Vec::new();
 
         data.write_field(
             Field::Temperature {
@@ -273,6 +274,6 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(buf, "35");
+        assert_eq!(String::from_utf8(buf).unwrap(), "35");
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -88,8 +88,14 @@ fn main() -> Result<()> {
         config.tooltip.retain_lines_with_values(&gpu_status_data);
     }
 
-    let text_state = State::try_from_format(&config.text.format)?;
-    let tooltip_state = State::try_from_format(config.tooltip.format())?;
+    // Escape special chars in the formats to make the JSON output valid.
+    // Also make line breaks literal (\n -> \\n), because we don't want
+    // to flush stdout before the whole JSON content is ready in the stdout buffer.
+    let escaped_text_format = json_escape_simd::escape(&config.text.format);
+    let escaped_tooltip_format = json_escape_simd::escape(config.tooltip.format());
+
+    let text_state = State::try_from_format(escaped_text_format)?;
+    let tooltip_state = State::try_from_format(escaped_tooltip_format)?;
 
     let update_interval = Duration::from_millis(config.general.interval);
 
@@ -97,7 +103,12 @@ fn main() -> Result<()> {
 
     loop {
         let gpu_status_data = gpu_status_handler.compute()?;
-        write_json(
+
+        // Static string chunks in `text_state` and `tooltip_state`
+        // were properly escaped with `json_escape_simd` before the loop.
+        // **Variable chunks should not yields special characters that
+        // should be escaped, either, which is unchecked.**
+        write_json_unchecked(
             &mut stdout_lock,
             &gpu_status_data,
             &text_state,
@@ -112,7 +123,12 @@ fn main() -> Result<()> {
 /// ```json
 /// {"text": "...", "tooltip": "..."}
 /// ```
-fn write_json(
+///
+/// This function does not escape characters for you.
+/// Callers have to make sure `text_state` and `tooltip_state`
+/// does not contains strings such as `\n`, `"`, ... that
+/// could break JSON.
+fn write_json_unchecked(
     buffer: &mut impl Write,
     data: &GpuStatusData,
     text_state: &State,

--- a/src/main.rs
+++ b/src/main.rs
@@ -108,7 +108,10 @@ fn main() -> Result<()> {
     }
 }
 
-// {"text":"Idle","tooltip":"GPU idle"}
+/// Write `data` to waybar-flavored json:
+/// ```json
+/// {"text": "...", "tooltip": "..."}
+/// ```
 fn write_json(
     buffer: &mut impl Write,
     data: &GpuStatusData,

--- a/src/main.rs
+++ b/src/main.rs
@@ -91,8 +91,8 @@ fn main() -> Result<()> {
     // Escape special chars in the formats to make the JSON output valid.
     // Also make line breaks literal (\n -> \\n), because we don't want
     // to flush stdout before the whole JSON content is ready in the stdout buffer.
-    let escaped_text_format = json_escape_simd::escape(&config.text.format);
-    let escaped_tooltip_format = json_escape_simd::escape(config.tooltip.format());
+    let escaped_text_format = escape_json(&config.text.format);
+    let escaped_tooltip_format = escape_json(config.tooltip.format());
 
     let text_state = State::try_from_format(escaped_text_format)?;
     let tooltip_state = State::try_from_format(escaped_tooltip_format)?;
@@ -141,4 +141,15 @@ fn write_json_unchecked(
     writeln!(buffer, r#""}}"#)?;
 
     Ok(())
+}
+
+fn escape_json(s: &str) -> String {
+    let mut escaped = json_escape_simd::escape(s);
+
+    // json_escape_simd::escape wraps quotation marks around the string.
+    // Remove them for code readability in text/tooltip `State`s and `write_json_unchecked`.
+    escaped.remove(0);
+    escaped.pop();
+
+    escaped
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -115,6 +115,9 @@ fn main() -> Result<()> {
             &tooltip_state,
         )?;
 
+        // Debug validate final JSON
+        assert_valid_json(&gpu_status_data, &text_state, &tooltip_state);
+
         std::thread::sleep(update_interval);
     }
 }
@@ -152,4 +155,22 @@ fn escape_json(s: &str) -> String {
     escaped.pop();
 
     escaped
+}
+
+#[cfg(debug_assertions)]
+/// Validates that [write_json_unchecked] produces a parseable JSON string.
+fn assert_valid_json(data: &GpuStatusData, text_state: &State, tooltip_state: &State) {
+    use sonic_rs::Value;
+
+    let mut buffer = Vec::new();
+    write_json_unchecked(&mut buffer, data, text_state, tooltip_state).unwrap();
+    let buf_s = str::from_utf8(&buffer).unwrap();
+
+    // parses the buffer string
+    let result = sonic_rs::from_str::<Value>(buf_s);
+
+    assert!(
+        result.is_ok(),
+        "Failed to parse JSON from string: The string may be invalid. Check if special characters are properly escaped."
+    );
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -104,10 +104,12 @@ fn main() -> Result<()> {
     loop {
         let gpu_status_data = gpu_status_handler.compute()?;
 
-        // Static string chunks in `text_state` and `tooltip_state`
-        // were properly escaped with `json_escape_simd` before the loop.
-        // **Variable chunks should not yields special characters that
-        // should be escaped, either, which is unchecked.**
+        // `Chunk::Static`s in `text_state` and `tooltip_state`
+        // have been escaped prior to the loop.
+        //
+        // Note: Variable chunks are also expected to contain no characters
+        // requiring escaping. This is unchecked for performance, but
+        // verified via debug assertions below.
         write_json_unchecked(
             &mut stdout_lock,
             &gpu_status_data,
@@ -115,7 +117,8 @@ fn main() -> Result<()> {
             &tooltip_state,
         )?;
 
-        // Debug validate final JSON
+        // Debug assert that `write_json_unchecked` produces valid JSON.
+        #[cfg(debug_assertions)]
         assert_valid_json(&gpu_status_data, &text_state, &tooltip_state);
 
         std::thread::sleep(update_interval);

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,21 +4,18 @@ pub mod formatter;
 pub mod gpu_status;
 pub mod nvidia;
 
-use std::{
-    io::{Write, stdout},
-    sync::OnceLock,
-    time::Duration,
-};
+use std::io::{self, Write};
+use std::{io::stdout, sync::OnceLock, time::Duration};
 
 use clap::Parser;
 use color_eyre::eyre::{Result, eyre};
 use nvml_wrapper::Nvml;
-use serde::Serialize;
 
+use crate::gpu_status::GpuStatusData;
 use crate::{
     amd::{AmdGpuStatus, AmdSysFS},
     formatter::State,
-    gpu_status::{GpuStatus, GpuStatusData},
+    gpu_status::GpuStatus,
     nvidia::NvidiaGpuStatus,
 };
 
@@ -91,8 +88,8 @@ fn main() -> Result<()> {
         config.tooltip.retain_lines_with_values(&gpu_status_data);
     }
 
-    let mut text_state = State::try_from_format(&config.text.format)?;
-    let mut tooltip_state = State::try_from_format(config.tooltip.format())?;
+    let text_state = State::try_from_format(&config.text.format)?;
+    let tooltip_state = State::try_from_format(config.tooltip.format())?;
 
     let update_interval = Duration::from_millis(config.general.interval);
 
@@ -100,28 +97,29 @@ fn main() -> Result<()> {
 
     loop {
         let gpu_status_data = gpu_status_handler.compute()?;
-
-        let output = format_output(&gpu_status_data, &mut text_state, &mut tooltip_state);
-
-        writeln!(&mut stdout_lock, "{}", sonic_rs::to_string(&output)?)?;
+        write_json(
+            &mut stdout_lock,
+            &gpu_status_data,
+            &text_state,
+            &tooltip_state,
+        )?;
 
         std::thread::sleep(update_interval);
     }
 }
 
-fn format_output<'t, 'u>(
-    gpu_status: &GpuStatusData,
-    text_state: &'t mut State,
-    tooltip_state: &'u mut State,
-) -> OutputFormat<'t, 'u> {
-    OutputFormat {
-        text: gpu_status.get_text(text_state),
-        tooltip: gpu_status.get_tooltip(tooltip_state),
-    }
-}
+// {"text":"Idle","tooltip":"GPU idle"}
+fn write_json(
+    buffer: &mut impl Write,
+    data: &GpuStatusData,
+    text_state: &State,
+    tooltip_state: &State,
+) -> io::Result<()> {
+    write!(buffer, r#"{{"text":""#)?;
+    data.write_text(text_state, buffer)?;
+    write!(buffer, r#"","tooltip":""#)?;
+    data.write_tooltip(tooltip_state, buffer)?;
+    writeln!(buffer, r#""}}"#)?;
 
-#[derive(Default, Serialize)]
-struct OutputFormat<'t, 'u> {
-    text: &'t str,
-    tooltip: &'u str,
+    Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -161,7 +161,11 @@ fn escape_json(s: &str) -> String {
 }
 
 #[cfg(debug_assertions)]
-/// Validates that [write_json_unchecked] produces a parseable JSON string.
+/// Validates that [write_json_unchecked] produces a
+/// **single-line** valid JSON string.
+///
+/// It also ensures the output fits within the
+/// **1024-byte** stdout line buffer to prevent premature flushes.
 fn assert_valid_json(data: &GpuStatusData, text_state: &State, tooltip_state: &State) {
     use sonic_rs::Value;
 
@@ -169,8 +173,21 @@ fn assert_valid_json(data: &GpuStatusData, text_state: &State, tooltip_state: &S
     write_json_unchecked(&mut buffer, data, text_state, tooltip_state).unwrap();
     let buf_s = str::from_utf8(&buffer).unwrap();
 
-    // parses the buffer string
+    // parse the buffer string
     let result = sonic_rs::from_str::<Value>(buf_s);
+
+    // The output must not contain line breaks other
+    // than the last character or the stdout line
+    // buffer will flush early.
+    assert!(buf_s.ends_with('\n'));
+    assert!(!buf_s.chars().rev().skip(1).any(|c| c == '\n'));
+
+    // The output size must be under 1024 bytes to
+    // prevent the stdout buffer from flushing early.
+    assert!(
+        buf_s.len() < 1024,
+        "JSON output exceeds the 1024-byte stdout line buffer limit"
+    );
 
     assert!(
         result.is_ok(),


### PR DESCRIPTION
This is a minor optimization.

- Removed `State.buffer`: Output is now streamed directly to the standard output.
- Refactored Numeric Formatting: Replaced `trim_trailing_zeros()` with `write_with_precision()`. This allows us to format numbers directly into the output stream without needing a back-buffer for post-processing.
- Updated Tests: Adjusted test cases to align with the new direct-write logic.