### PR TITLE
Add config to select GPU index

### DIFF
--- a/src/amd.rs
+++ b/src/amd.rs
@@ -12,11 +12,15 @@ use crate::gpu_status::{GpuStatus, GpuStatusData, Temperature};
 
 pub struct AmdGpuStatus {
     amd_sys_fs: &'static AmdSysFS,
+    gpu_index: u8,
 }
 
 impl AmdGpuStatus {
-    pub const fn new(amd_sys_fs: &'static AmdSysFS) -> Result<Self> {
-        Ok(Self { amd_sys_fs })
+    pub const fn new(amd_sys_fs: &'static AmdSysFS, gpu_index: u8) -> Result<Self> {
+        Ok(Self {
+            amd_sys_fs,
+            gpu_index,
+        })
     }
 }
 
@@ -41,6 +45,7 @@ impl GpuStatus for AmdGpuStatus {
             powered_on: true,
             has_running_processes: true, /* TODO: temporarily set to true until AMD GPU process
                                           * detection is implemented */
+            gpu_index: Some(self.gpu_index),
             gpu_utilization: gpu_handle.get_busy_percent().ok(),
             mem_used: gpu_handle
                 .get_used_vram()

--- a/src/amd.rs
+++ b/src/amd.rs
@@ -83,11 +83,11 @@ impl AmdSysFS {
         let drm_dir = PathBuf::from("/sys/class/drm");
         let mut drm_gpus = Vec::new();
 
-        let card_regex = Regex::new(r"^card[0-9]*$")?;
+        let render_regex = Regex::new(r"^renderD([1-9][0-9]*)$")?;
 
         for entry in drm_dir.read_dir()? {
             let entry = entry?;
-            let mut path = entry.path();
+            let path = entry.path();
 
             if path.is_dir() {
                 let drm_device = path
@@ -96,12 +96,17 @@ impl AmdSysFS {
                     .to_str()
                     .ok_or(eyre!("Path isn't a valid UTF-8"))?;
 
-                if card_regex.is_match(drm_device) {
-                    path.push(PathBuf::from("device"));
-                    drm_gpus.push(path);
+                if let Some(captures) = render_regex.captures(drm_device) {
+                    let drm_minor = captures.get(1).unwrap().as_str();
+                    drm_gpus.push((drm_minor.parse::<usize>()?, path));
                 }
             }
         }
+        drm_gpus.sort_by_key(|(minor, _)| *minor);
+        let drm_gpus: Vec<PathBuf> = drm_gpus
+            .into_iter()
+            .map(|(_, path)| path.join("device"))
+            .collect();
 
         Ok(drm_gpus)
     }

--- a/src/amd.rs
+++ b/src/amd.rs
@@ -67,14 +67,14 @@ pub struct AmdSysFS {
 }
 
 impl AmdSysFS {
-    pub fn init() -> Result<Self> {
+    pub fn init(gpu_index: u8) -> Result<Self> {
         let drm_gpus = Self::get_drm_gpus()?;
 
         if drm_gpus.is_empty() {
             return Err(eyre!("No AMD GPU found"));
         }
 
-        let gpu_handle = GpuHandle::new_from_path(drm_gpus[0].clone())?;
+        let gpu_handle = GpuHandle::new_from_path(drm_gpus[gpu_index as usize].clone())?;
 
         Ok(Self { gpu_handle })
     }

--- a/src/config/structs.rs
+++ b/src/config/structs.rs
@@ -22,6 +22,9 @@ impl ConfigFile {
         if let Some(interval) = args.interval {
             self.general.interval = interval;
         }
+        if let Some(gpu_index) = args.gpu_index {
+            self.general.gpu_index = gpu_index;
+        }
         if let Some(ref text_format) = args.text_format {
             self.text.format = text_format.to_owned();
         }
@@ -47,6 +50,8 @@ pub struct TextConfig {
 pub struct GeneralConfig {
     #[default(1000)]
     pub interval: u64,
+    #[default(0)]
+    pub gpu_index: u8,
 }
 
 #[derive(Deserialize, SmartDefault)]

--- a/src/config/structs.rs
+++ b/src/config/structs.rs
@@ -62,7 +62,7 @@ pub struct TooltipConfig {
 }
 
 impl TooltipConfig {
-    pub const DEFAULT_FORMAT: &str = r"GPU: {gpu_utilization}%
+    pub const DEFAULT_FORMAT: &str = r"GPU({gpu_index}): {gpu_utilization}%
 MEM USED: {mem_used:MiB.0}/{mem_total:MiB} MiB ({mem_utilization}%)
 MEM R/W: {mem_rw}%
 DEC: {decoder_utilization}%

--- a/src/formatter/fields.rs
+++ b/src/formatter/fields.rs
@@ -84,6 +84,7 @@ impl TryFrom<FormatSegments<'_>> for Field {
 #[derive(Debug, Clone, Copy, PartialEq, Display, EnumString)]
 #[strum(serialize_all = "snake_case")]
 pub enum SimpleField {
+    GpuIndex,
     GpuUtilization,
     MemRw,
     MemUtilization,

--- a/src/gpu_status.rs
+++ b/src/gpu_status.rs
@@ -10,6 +10,8 @@ pub type Temperature = uom::si::f32::ThermodynamicTemperature;
 
 #[derive(Default)]
 pub struct GpuStatusData {
+    /// GPU index
+    pub(crate) gpu_index: Option<u8>,
     /// Whether any process is using GPU.
     pub(crate) has_running_processes: bool,
     /// Whether GPU is powered on at the PCI level.
@@ -143,6 +145,7 @@ impl GpuStatusData {
         }
 
         match field {
+            SimpleField::GpuIndex => d!(self.gpu_index),
             SimpleField::GpuUtilization => d!(self.gpu_utilization),
             SimpleField::MemRw => d!(self.mem_rw),
             SimpleField::MemUtilization => d!(self.compute_mem_usage()),

--- a/src/main.rs
+++ b/src/main.rs
@@ -84,7 +84,9 @@ fn main() -> Result<()> {
 
     let gpu_status_handler: Box<dyn GpuStatus> = match get_instance(config.general.gpu_index) {
         Instance::Nvml(nvml) => Box::new(NvidiaGpuStatus::new(nvml, config.general.gpu_index)?),
-        Instance::Amd(amd_sys_fs) => Box::new(AmdGpuStatus::new(amd_sys_fs)?),
+        Instance::Amd(amd_sys_fs) => {
+            Box::new(AmdGpuStatus::new(amd_sys_fs, config.general.gpu_index)?)
+        }
     };
 
     // If the the user didn't set a custom tooltip format,

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,14 +29,14 @@ pub enum Instance {
 
 impl Instance {
     /// Get the instance based on the GPU brand.
-    pub fn new() -> Result<Self> {
+    pub fn new(gpu_index: u8) -> Result<Self> {
         let modules = procfs::modules()?;
 
         if modules.contains_key("nvidia") {
             return Ok(Self::Nvml(Box::new(Nvml::init()?)));
         }
         if modules.contains_key("amdgpu") {
-            return Ok(Self::Amd(Box::new(AmdSysFS::init()?)));
+            return Ok(Self::Amd(Box::new(AmdSysFS::init(gpu_index)?)));
         }
 
         Err(eyre!("No supported GPU found"))
@@ -45,8 +45,8 @@ impl Instance {
 
 pub static INSTANCE: OnceLock<Instance> = OnceLock::new();
 
-fn get_instance() -> &'static Instance {
-    INSTANCE.get_or_init(|| Instance::new().unwrap())
+fn get_instance(gpu_index: u8) -> &'static Instance {
+    INSTANCE.get_or_init(|| Instance::new(gpu_index).unwrap())
 }
 
 #[derive(Parser, Debug)]
@@ -55,6 +55,10 @@ pub struct Args {
     /// Polling interval in milliseconds
     #[arg(long)]
     interval: Option<u64>,
+
+    /// The GPU index to use (default: 0).
+    #[arg(long)]
+    gpu_index: Option<u8>,
 
     /// The format you want to display for `text`.
     /// For example,"{gpu_utilization}%|{mem_utilization}%".
@@ -78,8 +82,8 @@ fn main() -> Result<()> {
 
     config.merge_args_into_config(&args)?;
 
-    let gpu_status_handler: Box<dyn GpuStatus> = match get_instance() {
-        Instance::Nvml(nvml) => Box::new(NvidiaGpuStatus::new(nvml)?),
+    let gpu_status_handler: Box<dyn GpuStatus> = match get_instance(config.general.gpu_index) {
+        Instance::Nvml(nvml) => Box::new(NvidiaGpuStatus::new(nvml, config.general.gpu_index)?),
         Instance::Amd(amd_sys_fs) => Box::new(AmdGpuStatus::new(amd_sys_fs)?),
     };
 

--- a/src/nvidia.rs
+++ b/src/nvidia.rs
@@ -184,11 +184,13 @@ impl GpuStatus for NvidiaGpuStatus<'_> {
             GpuPowerState::Off => GpuStatusData {
                 powered_on: false,
                 has_running_processes: false,
+                gpu_index: Some(self.gpu_index),
                 ..Default::default()
             },
             GpuPowerState::OnNoProcess => GpuStatusData {
                 powered_on: true,
                 has_running_processes: false,
+                gpu_index: Some(self.gpu_index),
                 ..Default::default()
             },
             GpuPowerState::PoweredOnInUse => self.collect_active_gpu_stats(),

--- a/src/nvidia.rs
+++ b/src/nvidia.rs
@@ -19,18 +19,23 @@ use crate::gpu_status::{GpuStatus, GpuStatusData, PState, Temperature};
 pub struct NvidiaGpuStatus<'a> {
     device: Device<'a>,
     bus_id: String,
+    gpu_index: u8,
 }
 
 impl NvidiaGpuStatus<'_> {
-    pub fn new(instance: &'static Nvml) -> Result<Self> {
-        let device = instance.device_by_index(0)?;
+    pub fn new(instance: &'static Nvml, gpu_index: u8) -> Result<Self> {
+        let device = instance.device_by_index(gpu_index as u32)?;
 
         // Query PCI info just once
         // NVML returns a PCI domain up to 0xffffffff; need to truncate
         // to match sysfs
         let bus_id = device.pci_info()?.bus_id.chars().skip(4).collect();
 
-        Ok(Self { device, bus_id })
+        Ok(Self {
+            device,
+            bus_id,
+            gpu_index,
+        })
     }
 }
 
@@ -71,7 +76,7 @@ fn is_powered_on(bus_id: &str) -> Result<bool> {
 /// # References
 ///
 /// <https://wiki.archlinux.org/title/PRIME#NVIDIA>
-fn has_running_processes() -> bool {
+fn has_running_processes(gpu_index: u8) -> bool {
     let procs = all_processes().expect("Can't read /proc");
 
     for proc in procs.flatten() {
@@ -85,7 +90,7 @@ fn has_running_processes() -> bool {
 
         for fd in fds.flatten() {
             if let FDTarget::Path(ref path) = fd.target
-                && path == "/dev/nvidia0"
+                && path == &format!("/dev/nvidia{gpu_index}")
             {
                 return true;
             }
@@ -101,7 +106,7 @@ impl NvidiaGpuStatus<'_> {
             return Ok(GpuPowerState::Off);
         }
 
-        if !has_running_processes() {
+        if !has_running_processes(self.gpu_index) {
             return Ok(GpuPowerState::OnNoProcess);
         }
 


### PR DESCRIPTION
This pull request adds support for selecting which GPU to monitor by index, improving multi-GPU system compatibility. It introduces a new `gpu_index` configuration option, updates both AMD and NVIDIA backends to respect this index, and exposes the GPU index in formatting fields and outputs.

I have AMD GPU and tested my changes on it. But I need somebody with NVIDIA to do the same.